### PR TITLE
refactor(notifications): improve data sizes, misc. refactoring

### DIFF
--- a/cache_mover/mover.py
+++ b/cache_mover/mover.py
@@ -369,12 +369,14 @@ def move_files_concurrently(files_to_move, config, dry_run=False, stop_event=Non
                 logging.error(f"Error processing {src}: {e}")
 
     elapsed_time = time() - start_time
-    avg_speed = total_bytes_moved / (1024 * 1024 * elapsed_time) if elapsed_time > 0 else 0
+    avg_speed = total_bytes_moved / elapsed_time if elapsed_time > 0 else 0
 
     if moved_count > 0:
+        # Convert to MB/s for logging
+        mb_per_second = avg_speed / (1024 * 1024)
         logging.info(
             f"Moved {moved_count} files ({_format_bytes(total_bytes_moved)}) "
-            f"in {elapsed_time:.1f}s ({avg_speed:.2f}MB/s)"
+            f"in {elapsed_time:.1f}s ({mb_per_second:.2f} MB/s)"
         )
 
-    return moved_count, total_bytes_moved, elapsed_time, avg_speed 
+    return moved_count, total_bytes_moved, elapsed_time, avg_speed

--- a/notifications/__init__.py
+++ b/notifications/__init__.py
@@ -111,7 +111,7 @@ class NotificationHandler:
             'files_moved': files_moved,
             'space_moved': format_bytes(total_bytes),
             'time_str': self._format_time(elapsed_time),
-            'avg_speed': avg_speed,
+            'avg_speed': format_bytes(avg_speed),
             'final_cache_usage': cache_usage,
             'cache_free_str': format_bytes(cache_free),
             'cache_total_str': format_bytes(cache_total),

--- a/notifications/__init__.py
+++ b/notifications/__init__.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from urllib.parse import urlparse
 from .discord_service import DiscordService
 from .slack_service import SlackService
+from .util import format_bytes
 
 @dataclass
 class NotificationConfig:
@@ -47,17 +48,6 @@ class NotificationHandler:
                 else:
                     self.apobj.add(url) # type: ignore
 
-    def _format_bytes(self, bytes: int, use_gib: bool = True) -> str:
-        if use_gib:
-            gib = bytes / (1024**3)
-            return f"{gib:.2f}GiB"
-        
-        for unit in ['B', 'KB', 'MB', 'GB', 'TB']:
-            if bytes < 1024:
-                return f"{bytes:.2f}{unit}"
-            bytes /= 1024
-        return f"{bytes:.2f}PB"
-    
     def _calculate_percentage(self, used: int, total: int) -> float:
         if total == 0:
             return 0.0
@@ -119,15 +109,15 @@ class NotificationHandler:
         
         notification_data = {
             'files_moved': files_moved,
-            'space_moved': self._format_bytes(total_bytes, use_gib=True),
+            'space_moved': format_bytes(total_bytes),
             'time_str': self._format_time(elapsed_time),
             'avg_speed': avg_speed,
             'final_cache_usage': cache_usage,
-            'cache_free_str': self._format_bytes(cache_free, use_gib=True),
-            'cache_total_str': self._format_bytes(cache_total, use_gib=True),
+            'cache_free_str': format_bytes(cache_free),
+            'cache_total_str': format_bytes(cache_total),
             'backing_usage': backing_usage,
-            'backing_free_str': self._format_bytes(backing_free, use_gib=True),
-            'backing_total_str': self._format_bytes(backing_total, use_gib=True),
+            'backing_free_str': format_bytes(backing_free),
+            'backing_total_str': format_bytes(backing_total),
             'backing_path': self.config.backing_path,
             'commit_hash': self.config.commit_hash
         }
@@ -234,9 +224,9 @@ class NotificationHandler:
                 # The type checker doesn't recognise that the condition above guarantees these variables won't be None, hence this hack
                 assert cache_free is not None ; assert cache_total is not None ; assert backing_free is not None ; assert backing_total is not None  # noqa: E702
                 message += (f"\n\n💽 Cache Status\n"
-                        f"Space: {self._format_bytes(cache_free)} Free of {self._format_bytes(cache_total)} Total\n"
+                        f"Space: {format_bytes(cache_free)} Free of {format_bytes(cache_total)} Total\n"
                         f"\n💾 Backing Status\n"
-                        f"Space: {self._format_bytes(backing_free)} Free of {self._format_bytes(backing_total)} Total")
+                        f"Space: {format_bytes(backing_free)} Free of {format_bytes(backing_total)} Total")
             
             try:
                 if not self.apobj.notify( # type: ignore
@@ -261,9 +251,9 @@ class NotificationHandler:
             "ℹ️ Cache Empty Report\n\n"
             "Empty cache mode activated but no files found!\n\n"
             f"💽 Cache Status\n"
-            f"Space: {self._format_bytes(cache_free)} Free of {self._format_bytes(cache_total)} Total\n"
+            f"Space: {format_bytes(cache_free)} Free of {format_bytes(cache_total)} Total\n"
             f"\n💾 Backing Status\n"
-            f"Space: {self._format_bytes(backing_free)} Free of {self._format_bytes(backing_total)} Total"
+            f"Space: {format_bytes(backing_free)} Free of {format_bytes(backing_total)} Total"
         )
 
         for service in self.discord_services:

--- a/notifications/discord_service.py
+++ b/notifications/discord_service.py
@@ -35,7 +35,7 @@ class DiscordService:
                 },
                 {
                     "name": "📈 Transfer Speed",
-                    "value": f"{data['avg_speed']:.1f} MB/s",
+                    "value": f"{data['avg_speed']}/s",
                     "inline": True
                 },
                 {

--- a/notifications/discord_service.py
+++ b/notifications/discord_service.py
@@ -1,13 +1,14 @@
-from datetime import datetime
-from typing import Dict, List, Any
+from datetime import datetime, timezone
+from typing import Any
 
 from .util import format_bytes, send_webhook
+
 
 class DiscordService:
     def __init__(self, webhook_url: str):
         self.webhook_url = webhook_url
 
-    def send_completion(self, data: Dict[str, Any]) -> bool:
+    def send_completion(self, data: dict[str, Any]) -> bool:
         embeds = [{
             "title": "🔄 Cache Move Complete",
             "color": 0x00ff00,
@@ -59,12 +60,12 @@ class DiscordService:
             "footer": {
                 "text": f"Version: {data['commit_hash'][:7] if data['commit_hash'] else 'unknown'}"
             },
-            "timestamp": datetime.utcnow().isoformat()
+            "timestamp": datetime.now(timezone.utc).isoformat()
         }]
 
         return send_webhook("Discord", self.webhook_url, {"embeds": embeds})
 
-    def send_error(self, error_msg: str, commit_hash: str = None) -> bool:
+    def send_error(self, error_msg: str, commit_hash: str | None = None) -> bool:
         embeds = [{
             "title": "❌ Cache Mover Error",
             "color": 0xff0000,
@@ -72,25 +73,34 @@ class DiscordService:
             "footer": {
                 "text": f"Version: {commit_hash[:7] if commit_hash else 'unknown'}"
             },
-            "timestamp": datetime.utcnow().isoformat()
+            "timestamp": datetime.now(timezone.utc).isoformat()
         }]
 
         return send_webhook("Discord", self.webhook_url, {"embeds": embeds})
 
-    def send_threshold_not_met(self, current_usage: float, threshold: float, commit_hash: str = None,
-                                  cache_free: int = None, cache_total: int = None,
-                                  backing_free: int = None, backing_total: int = None) -> bool:
+    def send_threshold_not_met(
+        self,
+        current_usage: float,
+        threshold: float,
+        commit_hash: str | None = None,
+        cache_free: int | None = None,
+        cache_total: int | None = None,
+        backing_free: int | None = None,
+        backing_total: int | None = None,
+    ) -> bool:
         description = f"Current cache usage ({current_usage:.1f}%) is below threshold ({threshold:.1f}%). No action required."
 
         if all(x is not None for x in [cache_free, cache_total, backing_free, backing_total]):
+            # The type checker doesn't recognise that the condition above guarantees these variables won't be None, hence this hack
+            assert cache_free is not None ; assert cache_total is not None ; assert backing_free is not None ; assert backing_total is not None  # noqa: E702
             cache_free_str = format_bytes(cache_free)
             cache_total_str = format_bytes(cache_total)
             backing_free_str = format_bytes(backing_free)
             backing_total_str = format_bytes(backing_total)
 
-            description += f"\n\n**💽 Cache Status**\n"
+            description += "\n\n**💽 Cache Status**\n"
             description += f"Space: {cache_free_str} Free of {cache_total_str} Total\n"
-            description += f"\n**💾 Backing Status**\n"
+            description += "\n**💾 Backing Status**\n"
             description += f"Space: {backing_free_str} Free of {backing_total_str} Total"
 
         embeds = [{
@@ -100,14 +110,19 @@ class DiscordService:
             "footer": {
                 "text": f"Version: {commit_hash[:7] if commit_hash else 'unknown'}"
             },
-            "timestamp": datetime.utcnow().isoformat()
+            "timestamp": datetime.now(timezone.utc).isoformat()
         }]
 
         return send_webhook("Discord", self.webhook_url, {"embeds": embeds})
 
-    def send_empty_cache(self, cache_free: int, cache_total: int,
-                    backing_free: int, backing_total: int,
-                    commit_hash: str = None) -> bool:
+    def send_empty_cache(
+        self,
+        cache_free: int,
+        cache_total: int,
+        backing_free: int,
+        backing_total: int,
+        commit_hash: str | None = None,
+    ) -> bool:
         embeds = [{
             "title": "ℹ️ Cache Empty Report",
             "color": 0x3498db,
@@ -121,6 +136,6 @@ class DiscordService:
             "footer": {
                 "text": f"Version: {commit_hash[:7] if commit_hash else 'unknown'}"
             },
-            "timestamp": datetime.utcnow().isoformat()
+            "timestamp": datetime.now(timezone.utc).isoformat()
         }]
         return send_webhook("Discord", self.webhook_url, {"embeds": embeds})

--- a/notifications/discord_service.py
+++ b/notifications/discord_service.py
@@ -1,15 +1,11 @@
-import logging
 from datetime import datetime
 from typing import Dict, List, Any
-import requests
+
+from .util import format_bytes, send_webhook
 
 class DiscordService:
     def __init__(self, webhook_url: str):
         self.webhook_url = webhook_url
-
-    def _format_bytes(self, bytes: int) -> str:
-        gib = bytes / (1024**3)
-        return f"{gib:.2f}GiB"
 
     def send_completion(self, data: Dict[str, Any]) -> bool:
         embeds = [{
@@ -65,8 +61,8 @@ class DiscordService:
             },
             "timestamp": datetime.utcnow().isoformat()
         }]
-        
-        return self._send_webhook({"embeds": embeds})
+
+        return send_webhook("Discord", self.webhook_url, {"embeds": embeds})
 
     def send_error(self, error_msg: str, commit_hash: str = None) -> bool:
         embeds = [{
@@ -78,8 +74,8 @@ class DiscordService:
             },
             "timestamp": datetime.utcnow().isoformat()
         }]
-        
-        return self._send_webhook({"embeds": embeds})
+
+        return send_webhook("Discord", self.webhook_url, {"embeds": embeds})
 
     def send_threshold_not_met(self, current_usage: float, threshold: float, commit_hash: str = None,
                                   cache_free: int = None, cache_total: int = None,
@@ -87,10 +83,10 @@ class DiscordService:
         description = f"Current cache usage ({current_usage:.1f}%) is below threshold ({threshold:.1f}%). No action required."
 
         if all(x is not None for x in [cache_free, cache_total, backing_free, backing_total]):
-            cache_free_str = self._format_bytes(cache_free)
-            cache_total_str = self._format_bytes(cache_total)
-            backing_free_str = self._format_bytes(backing_free)
-            backing_total_str = self._format_bytes(backing_total)
+            cache_free_str = format_bytes(cache_free)
+            cache_total_str = format_bytes(cache_total)
+            backing_free_str = format_bytes(backing_free)
+            backing_total_str = format_bytes(backing_total)
 
             description += f"\n\n**💽 Cache Status**\n"
             description += f"Space: {cache_free_str} Free of {cache_total_str} Total\n"
@@ -106,9 +102,9 @@ class DiscordService:
             },
             "timestamp": datetime.utcnow().isoformat()
         }]
-        
-        return self._send_webhook({"embeds": embeds})
-    
+
+        return send_webhook("Discord", self.webhook_url, {"embeds": embeds})
+
     def send_empty_cache(self, cache_free: int, cache_total: int,
                     backing_free: int, backing_total: int,
                     commit_hash: str = None) -> bool:
@@ -118,22 +114,13 @@ class DiscordService:
             "description": (
                 "Empty cache mode activated but no files found!\n\n"
                 f"💽 Cache Status\n"
-                f"Space: {self._format_bytes(cache_free)} Free of {self._format_bytes(cache_total)} Total\n"
+                f"Space: {format_bytes(cache_free)} Free of {format_bytes(cache_total)} Total\n"
                 f"\n💾 Backing Status\n"
-                f"Space: {self._format_bytes(backing_free)} Free of {self._format_bytes(backing_total)} Total"
+                f"Space: {format_bytes(backing_free)} Free of {format_bytes(backing_total)} Total"
             ),
             "footer": {
                 "text": f"Version: {commit_hash[:7] if commit_hash else 'unknown'}"
             },
             "timestamp": datetime.utcnow().isoformat()
         }]
-        return self._send_webhook({"embeds": embeds})
-
-    def _send_webhook(self, payload: Dict[str, Any]) -> bool:
-        try:
-            response = requests.post(self.webhook_url, json=payload)
-            response.raise_for_status()
-            return True
-        except Exception as e:
-            logging.error(f"Failed to send Discord webhook: {str(e)}")
-            return False
+        return send_webhook("Discord", self.webhook_url, {"embeds": embeds})

--- a/notifications/slack_service.py
+++ b/notifications/slack_service.py
@@ -1,13 +1,14 @@
-from typing import Dict, List, Any
+from typing import Any
 
 from .util import format_bytes, send_webhook
+
 
 class SlackService:
     def __init__(self, webhook_url: str):
         self.webhook_url = webhook_url
 
-    def send_completion(self, data: Dict[str, Any]) -> bool:
-        blocks = [
+    def send_completion(self, data: dict[str, Any]) -> bool:
+        blocks: list[dict[str, Any]] = [
             {
                 "type": "section",
                 "text": {
@@ -51,8 +52,8 @@ class SlackService:
 
         return send_webhook("Slack", self.webhook_url, {"blocks": blocks})
 
-    def send_error(self, error_msg: str, commit_hash: str = None) -> bool:
-        blocks = [
+    def send_error(self, error_msg: str, commit_hash: str | None = None) -> bool:
+        blocks: list[dict[str, Any]] = [
             {
                 "type": "section",
                 "text": {
@@ -82,23 +83,32 @@ class SlackService:
 
         return send_webhook("Slack", self.webhook_url, {"blocks": blocks})
 
-    def send_threshold_not_met(self, current_usage: float, threshold: float, commit_hash: str = None,
-                                  cache_free: int = None, cache_total: int = None,
-                                  backing_free: int = None, backing_total: int = None) -> bool:
+    def send_threshold_not_met(
+        self,
+        current_usage: float,
+        threshold: float,
+        commit_hash: str | None = None,
+        cache_free: int | None = None,
+        cache_total: int | None = None,
+        backing_free: int | None = None,
+        backing_total: int | None = None,
+    ) -> bool:
         message = f"Current cache usage ({current_usage:.1f}%) is below threshold ({threshold:.1f}%). No action required."
 
         if all(x is not None for x in [cache_free, cache_total, backing_free, backing_total]):
+            # The type checker doesn't recognise that the condition above guarantees these variables won't be None, hence this hack
+            assert cache_free is not None ; assert cache_total is not None ; assert backing_free is not None ; assert backing_total is not None  # noqa: E702
             cache_free_str = format_bytes(cache_free)
             cache_total_str = format_bytes(cache_total)
             backing_free_str = format_bytes(backing_free)
             backing_total_str = format_bytes(backing_total)
 
-            message += f"\n\n*💽 Cache Status*\n"
+            message += "\n\n*💽 Cache Status*\n"
             message += f"Space: {cache_free_str} Free of {cache_total_str} Total\n"
-            message += f"\n*💾 Backing Status*\n"
+            message += "\n*💾 Backing Status*\n"
             message += f"Space: {backing_free_str} Free of {backing_total_str} Total"
 
-        blocks = [
+        blocks: list[dict[str, Any]] = [
             {
                 "type": "section",
                 "text": {
@@ -128,10 +138,15 @@ class SlackService:
 
         return send_webhook("Slack", self.webhook_url, {"blocks": blocks})
 
-    def send_empty_cache(self, cache_free: int, cache_total: int,
-                    backing_free: int, backing_total: int,
-                    commit_hash: str = None) -> bool:
-        blocks = [
+    def send_empty_cache(
+        self,
+        cache_free: int,
+        cache_total: int,
+        backing_free: int,
+        backing_total: int,
+        commit_hash: str | None = None,
+    ) -> bool:
+        blocks: list[dict[str, Any]] = [
             {
                 "type": "section",
                 "text": {

--- a/notifications/slack_service.py
+++ b/notifications/slack_service.py
@@ -1,14 +1,10 @@
-import logging
 from typing import Dict, List, Any
-import requests
+
+from .util import format_bytes, send_webhook
 
 class SlackService:
     def __init__(self, webhook_url: str):
         self.webhook_url = webhook_url
-
-    def _format_bytes(self, bytes: int) -> str:
-        gib = bytes / (1024**3)
-        return f"{gib:.2f}GiB"
 
     def send_completion(self, data: Dict[str, Any]) -> bool:
         blocks = [
@@ -53,7 +49,7 @@ class SlackService:
                 ]
             })
 
-        return self._send_webhook({"blocks": blocks})
+        return send_webhook("Slack", self.webhook_url, {"blocks": blocks})
 
     def send_error(self, error_msg: str, commit_hash: str = None) -> bool:
         blocks = [
@@ -84,7 +80,7 @@ class SlackService:
                 ]
             })
 
-        return self._send_webhook({"blocks": blocks})
+        return send_webhook("Slack", self.webhook_url, {"blocks": blocks})
 
     def send_threshold_not_met(self, current_usage: float, threshold: float, commit_hash: str = None,
                                   cache_free: int = None, cache_total: int = None,
@@ -92,10 +88,10 @@ class SlackService:
         message = f"Current cache usage ({current_usage:.1f}%) is below threshold ({threshold:.1f}%). No action required."
 
         if all(x is not None for x in [cache_free, cache_total, backing_free, backing_total]):
-            cache_free_str = self._format_bytes(cache_free)
-            cache_total_str = self._format_bytes(cache_total)
-            backing_free_str = self._format_bytes(backing_free)
-            backing_total_str = self._format_bytes(backing_total)
+            cache_free_str = format_bytes(cache_free)
+            cache_total_str = format_bytes(cache_total)
+            backing_free_str = format_bytes(backing_free)
+            backing_total_str = format_bytes(backing_total)
 
             message += f"\n\n*💽 Cache Status*\n"
             message += f"Space: {cache_free_str} Free of {cache_total_str} Total\n"
@@ -130,8 +126,8 @@ class SlackService:
                 ]
             })
 
-        return self._send_webhook({"blocks": blocks})
-    
+        return send_webhook("Slack", self.webhook_url, {"blocks": blocks})
+
     def send_empty_cache(self, cache_free: int, cache_total: int,
                     backing_free: int, backing_total: int,
                     commit_hash: str = None) -> bool:
@@ -150,9 +146,9 @@ class SlackService:
                     "text": (
                         "Empty cache mode activated but no files found!\n\n"
                         f"💽 Cache Status\n"
-                        f"Space: {self._format_bytes(cache_free)} Free of {self._format_bytes(cache_total)} Total\n"
+                        f"Space: {format_bytes(cache_free)} Free of {format_bytes(cache_total)} Total\n"
                         f"\n💾 Backing Status\n"
-                        f"Space: {self._format_bytes(backing_free)} Free of {self._format_bytes(backing_total)} Total"
+                        f"Space: {format_bytes(backing_free)} Free of {format_bytes(backing_total)} Total"
                     )
                 }
             }
@@ -165,13 +161,4 @@ class SlackService:
                     "text": f"Version: {commit_hash[:7]}"
                 }]
             })
-        return self._send_webhook({"blocks": blocks})
-
-    def _send_webhook(self, payload: Dict[str, Any]) -> bool:
-        try:
-            response = requests.post(self.webhook_url, json=payload)
-            response.raise_for_status()
-            return True
-        except Exception as e:
-            logging.error(f"Failed to send Slack webhook: {str(e)}")
-            return False
+        return send_webhook("Slack", self.webhook_url, {"blocks": blocks})

--- a/notifications/util.py
+++ b/notifications/util.py
@@ -1,5 +1,8 @@
 import logging
+from typing import Any
+
 import requests
+
 
 # Source https://stackoverflow.com/a/1094933/5209106
 def format_bytes(bytes: int | float, suffix: str = "B") -> str:
@@ -9,7 +12,7 @@ def format_bytes(bytes: int | float, suffix: str = "B") -> str:
         bytes /= 1024
     return f"{bytes:.1f}Yi{suffix}"
 
-def send_webhook(service_name: str, webhook_url: str, payload: Dict[str, Any]) -> bool:
+def send_webhook(service_name: str, webhook_url: str, payload: dict[str, Any]) -> bool:
     try:
         response = requests.post(webhook_url, json=payload)
         response.raise_for_status()

--- a/notifications/util.py
+++ b/notifications/util.py
@@ -1,9 +1,13 @@
 import logging
 import requests
 
-def format_bytes(self, bytes: int) -> str:
-    gib = bytes / (1024**3)
-    return f"{gib:.2f}GiB"
+# Source https://stackoverflow.com/a/1094933/5209106
+def format_bytes(bytes: int | float, suffix: str = "B") -> str:
+    for unit in ("", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"):
+        if abs(bytes) < 1024:
+            return f"{bytes:3.1f}{unit}{suffix}"
+        bytes /= 1024
+    return f"{bytes:.1f}Yi{suffix}"
 
 def send_webhook(service_name: str, webhook_url: str, payload: Dict[str, Any]) -> bool:
     try:

--- a/notifications/util.py
+++ b/notifications/util.py
@@ -1,0 +1,15 @@
+import logging
+import requests
+
+def format_bytes(self, bytes: int) -> str:
+    gib = bytes / (1024**3)
+    return f"{gib:.2f}GiB"
+
+def send_webhook(service_name: str, webhook_url: str, payload: Dict[str, Any]) -> bool:
+    try:
+        response = requests.post(webhook_url, json=payload)
+        response.raise_for_status()
+        return True
+    except Exception as e:
+        logging.error(f"Failed to send {service_name} webhook: {str(e)}")
+        return False

--- a/notifications/util.py
+++ b/notifications/util.py
@@ -8,9 +8,9 @@ import requests
 def format_bytes(bytes: int | float, suffix: str = "B") -> str:
     for unit in ("", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"):
         if abs(bytes) < 1024:
-            return f"{bytes:3.1f}{unit}{suffix}"
+            return f"{bytes:3.1f} {unit}{suffix}"
         bytes /= 1024
-    return f"{bytes:.1f}Yi{suffix}"
+    return f"{bytes:.1f} Yi{suffix}"
 
 def send_webhook(service_name: str, webhook_url: str, payload: dict[str, Any]) -> bool:
     try:


### PR DESCRIPTION
* Convert data values <1GiB or >=1024GiB to the closest appropriate unit
	* Also added space between values (e.g. `1GiB` -> `1 GiB`)
* Reduce code duplication
* Fix type errors

There are quite a lot of changes here (scope creep, whoops), but the only visible change as far as users are concerned is the improvement to how data sizes are represented in the notifications:

![image](https://github.com/user-attachments/assets/b79f9652-1a2b-4284-a3a3-aa7211f83a15)
