### PR TITLE
fix(config): deep-copy DEFAULT_CONFIG to avoid shared mutable defaults

### DIFF
--- a/cache_mover/config.py
+++ b/cache_mover/config.py
@@ -1,4 +1,5 @@
 import os
+import copy
 import yaml
 import logging
 
@@ -45,7 +46,7 @@ def get_script_dir():
     return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 def load_config(config_path=None):
-    config = DEFAULT_CONFIG.copy()
+    config = copy.deepcopy(DEFAULT_CONFIG)
     
     if config_path:
         if not os.path.exists(config_path):


### PR DESCRIPTION
`load_config` used a shallow `DEFAULT_CONFIG.copy()`, so the nested Settings and Paths dicts were shared with the module-level default.

Mutating them (via `.update()` and `env-var` assignment) polluted `DEFAULT_CONFIG` for any subsequent `load_config` call.

Currently not an issue in production (called once per run) but incorrect and unsafe if tests are added or it is called repeated calls.

I've came across this when doing some testing on it with AI and it repeatedly chokes on it ;)